### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   # Start chromium via wrapper script with --no-sandbox argument:
   && mv /usr/lib/chromium/chromium /usr/lib/chromium/chromium-original \
   && printf '%s\n' '#!/bin/sh' \
-    'exec /usr/lib/chromium/chromium-original --no-sandbox "$@"' \
+    'exec /usr/lib/chromium/chromium-original --no-sandbox --disable-dev-shm-usage "$@"' \
     > /usr/lib/chromium/chromium && chmod +x /usr/lib/chromium/chromium \
   # Remove obsolete files:
   && apt-get clean \


### PR DESCRIPTION
Use the `--disable-dev-shm-usage` flag as stated in https://github.com/GoogleChrome/puppeteer/blob/v1.0.0/docs/troubleshooting.md#tips:
> By default, Docker runs a container with a /dev/shm shared memory space 64MB. This is typically too small for Chrome and will cause Chrome to crash when rendering large pages. To fix, run the container with docker run --shm-size=1gb to increase the size of /dev/shm. Since Chrome 65, this is no longer necessary. Instead, launch the browser with the --disable-dev-shm-usage flag